### PR TITLE
Fixed ORCA encoder adding "None" when not providing basis set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Fixed
+
+- ORCA encoder no longer writes `None` if no basis (e.g., when no basis is needed for an XTB calculation). [#42](https://github.com/coltonbh/qccodec/pull/42) by [TroyNSmith](https://github.com/TroyNSmith)
+
 ## [0.10.0] - 2026-03-26
 
 ### Changed

--- a/src/qccodec/encoders/orca.py
+++ b/src/qccodec/encoders/orca.py
@@ -96,7 +96,12 @@ def encode(program_input: ProgramInput) -> NativeInput:
         inp_lines.append("")
 
     # Method and Basis
-    inp_lines.append(f"! {program_input.model.method} {program_input.model.basis}")
+    model_line = f"! {program_input.model.method}"
+    # ORCA will not recognize 'None' when using composite methods
+    if program_input.model.basis:
+        model_line += f" {program_input.model.basis}"
+
+    inp_lines.append(model_line)
 
     # NumGrad. May be used for gradients or optimizations
     if "numgrad" in kw_lower:

--- a/tests/test_orca_encoders.py
+++ b/tests/test_orca_encoders.py
@@ -81,6 +81,17 @@ def test_write_input_files(
                 )
 
 
+def test_no_none_fields():
+    """Tests 'None' not in input file when basis not provided."""
+    program_input = ProgramInput(
+        calctype=CalcType.optimization, model=Model(method="xTB"), structure=water
+    )
+    native_input = encode(program_input)
+    input_file = native_input.input_file
+
+    assert "None" not in input_file, f"'None' found in\n{input_file}"
+
+
 def test_validate_keywords_raises_error_if_coords_block_in_keywords():
     """The 'coords' block should not be set directly as a keyword."""
 


### PR DESCRIPTION
Added test to check "None" is not entered into input file through ORCA encoder.