### PR TITLE
Parsing fixes for ORCA xTB (Fixes #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Fixed
+- Deleted ORCA `parse_natoms` to fix parsing of xTB log files.
+- Fixed gradient regex to account for arbitrary number of stars in log file.
+
+
 ## [0.10.1] - 2026-05-02
 
 ### Fixed

--- a/src/qccodec/parsers/orca.py
+++ b/src/qccodec/parsers/orca.py
@@ -147,7 +147,9 @@ def parse_hessian(contents: str) -> list[list[float]]:
     for block in blocks:
         lines = block.splitlines()
         if not len(lines) == dim:
-            raise ParserError(f"Block line count {len(lines)} does not match dimension {dim}: {block}")
+            raise ParserError(
+                f"Block line count {len(lines)} does not match dimension {dim}: {block}"
+            )
 
         for i, line in enumerate(block.splitlines()):
             row = list(map(float, line.split()[1:]))
@@ -194,9 +196,10 @@ def parse_trajectory(
 
     # Capture the stdout for each gradient calculation
     regex = (
-        r"GEOMETRY\s*OPTIMIZATION\s*CYCLE\s*\d+\s*\*\s*\n\s*\**\s*\n"  # header
-        r"(.*?)"  # body
-        r"-*\s*\n\s*ORCA\s+GEOMETRY\s+RELAXATION\s+STEP"
+        r"GEOMETRY\s*OPTIMIZATION\s*CYCLE\s*\d+.*?"  # Match cycle line
+        r"\*+\n"  # Match the line of stars
+        r"(.*?)"  # Body (Captured)
+        r"-+\s*\n\s*ORCA\s+GEOMETRY\s+RELAXATION\s+STEP"  # Footer
     )
     per_gradient_stdout = re.findall(regex, stdout, flags=re.DOTALL)
     if not per_gradient_stdout:
@@ -247,21 +250,6 @@ def parse_version(contents: str) -> str:
     regex = r"Program Version (\d+\.\d+\.\d+)"
     match = re_search(regex, contents)
     return match.group(1)
-
-
-@register(filetype=OrcaFileType.STDOUT, target="calcinfo_natoms")
-def parse_natoms(contents: str) -> int:
-    """Parse number of atoms value from Orca stdout.
-
-    Returns:
-        The number of atoms as an integer.
-
-    Raises:
-        MatchNotFoundError: If the regex does not match.
-    """
-    regex = r"Number of atoms\s*...\s*(\d+)"
-    match = re_search(regex, contents)
-    return int(match.group(1))
 
 
 def parse_basename(contents: str) -> str:

--- a/tests/data/orca/answers/trajectory.json
+++ b/tests/data/orca/answers/trajectory.json
@@ -69,7 +69,7 @@
     },
     "success": true,
     "data": {
-      "calcinfo_natoms": 3,
+      "calcinfo_natoms": null,
       "calcinfo_nalpha": null,
       "calcinfo_nbeta": null,
       "calcinfo_nbasis": null,
@@ -187,7 +187,7 @@
     },
     "success": true,
     "data": {
-      "calcinfo_natoms": 3,
+      "calcinfo_natoms": null,
       "calcinfo_nalpha": null,
       "calcinfo_nbeta": null,
       "calcinfo_nbasis": null,
@@ -305,7 +305,7 @@
     },
     "success": true,
     "data": {
-      "calcinfo_natoms": 3,
+      "calcinfo_natoms": null,
       "calcinfo_nalpha": null,
       "calcinfo_nbeta": null,
       "calcinfo_nbasis": null,
@@ -423,7 +423,7 @@
     },
     "success": true,
     "data": {
-      "calcinfo_natoms": 3,
+      "calcinfo_natoms": null,
       "calcinfo_nalpha": null,
       "calcinfo_nbeta": null,
       "calcinfo_nbasis": null,

--- a/tests/test_orca_parsers.py
+++ b/tests/test_orca_parsers.py
@@ -7,7 +7,6 @@ from qccodec.parsers.orca import (
     parse_energy,
     parse_gradient,
     parse_hessian,
-    parse_natoms,
     parse_trajectory,
     parse_version,
 )
@@ -86,14 +85,6 @@ test_cases = [
         success=True,
         answer=hessians.water_revdsd,
         extra_files=["water.numhess.hess"],
-    ),
-    ParserTestCase(
-        name="Parse number of atoms water",
-        parser=parse_natoms,
-        stdout=Path("water.energy.out"),
-        calctype=CalcType.energy,
-        success=True,
-        answer=3,
     ),
     ParserTestCase(
         name="Parse trajectory",


### PR DESCRIPTION
@coltonbh @TroyNSmith This fixes the broken tests from PR #43.

The reason for dropping the `natoms` parser is that the number of atoms line is not always printed, for example when running `xTB` through Orca.